### PR TITLE
Add TS and rimraf to Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,11 @@
       {
         devShell = pkgs.mkShell {
           name = "oddjs";
-          buildInputs = with pkgs; [ nodejs-18_x ];
+          buildInputs = with pkgs; [
+            nodejs-18_x
+            nodePackages.rimraf
+            nodePackages.typescript
+          ];
         };
       });
 }


### PR DESCRIPTION
## Summary

I'm on a relatively fresh system, and don't have global JS/TS tooling set up. I was unable to run npm tasks in this repo without installing TypeScript and `rimraf`.

This PR adds them to the Flake environment!